### PR TITLE
Add a possibility to deploy CCP using non-root user

### DIFF
--- a/roles/ccp-build/tasks/main.yaml
+++ b/roles/ccp-build/tasks/main.yaml
@@ -2,6 +2,7 @@
   shell: ccp --config-file={{ ccp_conf }} fetch
   run_once: true
   when: ccp_fetch|default(true)
+  become: true
 
 - name: Reset projects before patching
   shell: git reset --hard origin/master
@@ -10,16 +11,19 @@
   run_once: true
   with_items: "{{ ccp_gerrit_reviews }}"
   when: ccp_gerrit_reviews|length > 0
+  become: true
 
 - name: Patch projects
-  shell: git fetch "{{ ccp_gerrit_base }}/{{ item.repo }}" {{ item.refspec }} && git cherry-pick FETCH_HEAD
+  shell: git fetch "{{ ccp_gerrit_base }}/{{ item.repo }}" {{ item.refspec }} && git cherry-pick --no-commit FETCH_HEAD
   args:
     chdir: "{{ ccp_ms_root }}/{{ item.repo }}"
   run_once: true
   with_items: "{{ ccp_gerrit_reviews }}"
   when: ccp_gerrit_reviews|length > 0
+  become: true
 
 - name: Build CCP images
   shell: "ccp --config-file={{ ccp_conf }} build >> /var/log/ccp-build.log 2>&1"
   run_once: true
   when: ccp_build|default(true)
+  become: true

--- a/roles/ccp-cli/tasks/main.yaml
+++ b/roles/ccp-cli/tasks/main.yaml
@@ -3,6 +3,7 @@
     repo: "{{ ccp_repo }}"
     dest: /usr/local/src/fuel-ccp
     version: "{{ ccp_commit }}"
+  become: true
 
 - name: Install CCP cli tool
   shell: pip install -U fuel-ccp/
@@ -10,9 +11,11 @@
     chdir: /usr/local/src
     creates: /usr/local/bin/ccp
   when: not ccp_cli_upgrade|default(false)
+  become: true
 
 - name: Upgrade CCP cli tool
   shell: pip install -U fuel-ccp/
   args:
     chdir: /usr/local/src
   when: ccp_cli_upgrade|default(false)
+  become: true

--- a/roles/ccp-conf/tasks/main.yaml
+++ b/roles/ccp-conf/tasks/main.yaml
@@ -1,5 +1,6 @@
 - name: Create dir
   file: path={{ ccp_misc_dir }} state=directory mode=0755
+  become: true
 
 - name: Create ccp.conf
   template:
@@ -8,6 +9,7 @@
     owner: root
     group: root
     mode: 0600
+  become: true
 
 - name: Create deploy-config.yaml
   template:
@@ -16,4 +18,5 @@
     owner: root
     group: root
     mode: 0600
+  become: true
 

--- a/roles/ccp-deploy/tasks/main.yaml
+++ b/roles/ccp-deploy/tasks/main.yaml
@@ -24,6 +24,7 @@
   run_once: true
   when: get_ns.stdout.find('{{ ccp_namespace }}') == -1
         or ccp_redeploy|default(false)
+  become: true
 
 - name: Get resolv.conf
   shell: cat /etc/resolv.conf
@@ -34,3 +35,5 @@
   when: resolv_conf.stdout.find('{{ item }}') == -1 and ccp_hacks|default(true)
   with_items:
     - "{{ ccp_namespace }}.svc.cluster.local"
+    - "kube-system.svc.cluster.local"
+  become: true

--- a/roles/registry/tasks/main.yaml
+++ b/roles/registry/tasks/main.yaml
@@ -1,5 +1,6 @@
 - name: Create dir
   file: path={{ ccp_misc_dir }} state=directory mode=0755
+  become: true
 
 - name: Create registry_pod.yaml
   template:
@@ -8,6 +9,7 @@
     owner: root
     group: root
     mode: 0644
+  become: true
 
 - name: Create registry_svc.yaml.j2
   template:
@@ -16,6 +18,7 @@
     owner: root
     group: root
     mode: 0644
+  become: true
 
 - name: Get pods
   shell: kubectl get pods --namespace={{ ccp_registry_ns }}
@@ -33,6 +36,7 @@
     chdir: /root/ccp
   run_once: true
   when: get_pod.stdout.find('registry') == -1
+  become: true
 
 - name: Create registry svc
   shell: kubectl create -f "{{ ccp_misc_dir }}/registry_svc.yaml" --namespace={{ ccp_registry_ns }}
@@ -40,3 +44,4 @@
     chdir: /root/ccp
   run_once: true
   when: get_svc.stdout.find('registry') == -1
+  become: true


### PR DESCRIPTION
Now it's possible to run ansible-playbook by **non-root** user which has **sudo** on target nodes.
Also don't commit changes while doing cherry-pick(s) to prevent git error _'_fatal: unable to auto-detect email address_'_.
