### PR TITLE
Add domain for CCP namespace before deploy

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,8 +1,9 @@
+- hosts: k8s-cluster
+  roles:
+    - { role: ccp-hacks, tags: ccp-hacks }
+
 - hosts: kube-master
   roles:
     - { role: ccp-conf, tags: ccp-conf }
     - { role: ccp-deploy, tags: ccp-deploy }
 
-- hosts: k8s-cluster
-  roles:
-    - { role: ccp-hacks, tags: ccp-hacks }


### PR DESCRIPTION
Currently resolv.conf is changed after OpenStack
deployment, so containers with host networking
(e.g. calico-dhcp) do not have required for correct
resolving info.
